### PR TITLE
feat: tag-driven struct field logging with omit/redact modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Fast and feature-rich structured logging library for Go
 - [Advanced Features](#advanced-features)
   - [Custom Colorizers](#custom-colorizers)
   - [Call Stack Logging](#call-stack-logging)
-  - [Redacting Sensitive Data](#redacting-sensitive-data)
+  - [Struct Field Logging: Tags and Modifiers](#struct-field-logging-tags-and-modifiers)
   - [Custom Levels](#custom-levels)
   - [Level Filtering](#level-filtering)
   - [Parsing Log Timestamps](#parsing-log-timestamps)
@@ -55,6 +55,7 @@ Fast and feature-rich structured logging library for Go
 
 - **High Performance**: Zero-allocation logging for JSON, text, and complex fields (error, time.Time)
 - **Structured Logging**: Type-safe field methods for all Go primitives including native time.Time and UUID
+- **Tag-driven Struct Logging**: `StructFields` and `TaggedStructFields` honor `golog`, `log`, and `json` tags with `omitempty`, `omitzero`, `omitnull`, and `redact` modifiers. `encoding/json`-compatible where applicable
 - **Multiple Output Formats**: JSON and human-readable text output
 - **Terminal Auto-Detection**: Automatically switches between colored text (TTY) and JSON (non-TTY)
 - **Configurable Log Levels**: TRACE, DEBUG, INFO, WARN, ERROR, FATAL with flexible filtering
@@ -497,30 +498,95 @@ defer func() {
 }()
 ```
 
-### Redacting Sensitive Data
+### Struct Field Logging: Tags and Modifiers
 
-Use the `golog:"redact"` struct tag to automatically redact sensitive fields when logging structs:
+`StructFields` and `TaggedStructFields` walk a struct via reflection and log
+each matching field as an attribute. They are driven entirely by struct tags,
+with modifiers that mirror `encoding/json.Marshal` semantics plus a handful of
+golog-specific additions.
+
+#### Tag resolution
+
+`StructFields(s)` looks for tags in this order — **first match wins**:
+
+1. `golog:"..."`
+2. `log:"..."`
+3. `json:"..."`
+
+Only the first tag present on a field is consulted. Other tags on the same field
+are ignored. Fields with **none** of those tags are skipped entirely (this is a
+deliberate difference from `encoding/json.Marshal`, which would use the Go field
+name: golog errs on the side of not leaking untagged internal fields into logs).
+
+`TaggedStructFields(s, "json")` does the same with a single caller-chosen tag.
+
+**Wildcard escape hatch:** passing the empty string as the key tag,
+`TaggedStructFields(s, "")`, matches every exported field with no rename and no
+modifiers — every field is logged under its Go name, struct tags ignored. Use
+this when you want to dump a struct wholesale and you don't care about per-field
+tags. (`StructFields(s)` deliberately stays strict tag-driven; the wildcard is
+opt-in.)
+
+#### Tag value grammar
+
+Each tag value is `name,mod1,mod2,...`:
+
+| Tag value                    | Log key       | Notes                                     |
+|------------------------------|---------------|-------------------------------------------|
+| `"field_name"`               | `field_name`  | explicit name                             |
+| `""`                         | Go field name | empty → fall back to field name            |
+| `",omitempty"`               | Go field name | empty name with modifier → fall back       |
+| `"-"` (bare, no comma)       | *skipped*     | only the bare form skips                  |
+| `"-,..."` (comma follows)    | `-`           | literal field name `-` + modifiers        |
+
+Whitespace around the name and each modifier is trimmed. Unknown modifier
+tokens are ignored silently, so `json:"name,omitnull"` is a valid tag for both
+`encoding/json.Marshal` (which ignores `omitnull`) and golog (which honors it).
+
+#### Modifiers
+
+| Modifier    | Suppress when…                                                                 |
+|-------------|---------------------------------------------------------------------------------|
+| `omitempty` | `false`, `0`, nil pointer/interface, empty array/slice/map/string. Exactly matches `encoding/json.Marshal`. Does **not** catch zero structs or `time.Time{}`. |
+| `omitzero`  | The type's `IsZero() bool` method returns true, **or** the value is the Go zero value (via `reflect.Value.IsZero`). Catches `time.Time{}` and any zero struct. Strict superset of `encoding/json`'s Go 1.24 `omitzero`. Both value-receiver and pointer-receiver `IsZero` methods are honored. |
+| `omitnull`  | The type's `IsNull() bool` method returns true. Falls back to `omitzero` semantics when the type has no `IsNull` method. Use for nullable wrappers (`golog.Timestamp`, `sql.NullString`, `uu.NullableID`) where "null" is richer than "all bytes zero". Both value-receiver and pointer-receiver `IsNull` methods are honored. |
+| `redact`    | (not a suppression modifier) — replaces the value with `"***REDACTED***"` before it reaches the writer. Also spelled `redacted`. Suppression modifiers win over redact: `json:",redact,omitempty"` on an empty string emits nothing, not the marker. |
+
+Modifiers OR together — any passing check suppresses the field.
+
+#### Complete example
 
 ```go
 type User struct {
-    ID       int    `json:"id"`
-    Username string `json:"username"`
-    Password string `json:"password" golog:"redact"`
-    APIKey   string `json:"api_key"  golog:"redact"`
+    ID        int             `json:"id"`
+    Name      string          `json:"name,omitempty"`
+    APIKey    string          `json:",redact"`
+    CreatedAt time.Time       `json:"created_at,omitzero"`
+    DeletedAt golog.Timestamp `json:"deleted_at,omitnull"`
+    Internal  string          // no json/log/golog tag → never logged
 }
 
 user := User{
-    ID:       123,
-    Username: "john_doe",
-    Password: "secret123",
-    APIKey:   "sk-abc123",
+    ID:        123,
+    Name:      "john_doe",
+    APIKey:    "sk-abc123",
+    CreatedAt: time.Now(),
+    // DeletedAt left as zero Timestamp
+    Internal:  "debug-only",
 }
 
-log.Info("User logged in").StructFields(user).Log()
-// Output: ... id=123 username="john_doe" password="***REDACTED***" api_key="***REDACTED***"
+log.Info("user").TaggedStructFields(user, "json").Log()
+// Output: ... id=123 name="john_doe" APIKey="***REDACTED***" created_at="2026-04-14T..."
+// (DeletedAt suppressed by omitnull, Internal never considered.)
 ```
 
-The `golog:"redact"` tag works with both `StructFields()` and `TaggedStructFields()` methods.
+> **Breaking changes in this release**
+>
+> - `golog:"redact"` (bare, single token) **no longer triggers redaction** — under the unified parser it names the field `"redact"`. Migrate to `golog:",redact"` (or combine with other modifiers: `golog:",redact,omitempty"`).
+> - `StructFields(s)` on an untagged struct now logs **nothing**. Previously it logged every exported field by its Go name. The cleanest replacement is `TaggedStructFields(s, "")`, the wildcard escape hatch documented above. Per-field, you can also add an empty tag like `json:""` or `golog:""` to opt in.
+> - `TaggedStructFields(s, "json")` with `json:""` now logs the field (Go field name), previously it skipped. This is `encoding/json.Marshal` parity.
+
+`omitnull` vs `omitzero`, concretely: `sql.NullString{Valid: false, String: ""}` and `sql.NullString{Valid: true, String: ""}` are both the reflect zero value, but only the first is actually null. `omitnull` with a proper `IsNull` method distinguishes the two; `omitzero` cannot.
 
 ### Custom Levels
 

--- a/message.go
+++ b/message.go
@@ -10,7 +10,6 @@ import (
 	"go/token"
 	"net/http"
 	"reflect"
-	"strings"
 	"time"
 	"unicode/utf8"
 )
@@ -385,24 +384,56 @@ func (m *Message) tryWriteInterface(w Writer, val reflect.Value) (written bool) 
 	return false
 }
 
-// StructFields calls Any(fieldName, fieldValue) for every exported struct field.
-// Fields with the tag `golog:"redact"` will have their value replaced with "***REDACTED***".
+// StructFields logs each exported field of strct whose struct tag matches,
+// in order, one of "golog", "log", "json". The first tag present on a field
+// determines both the log key and which modifiers apply; other tags on the
+// same field are ignored.
+//
+// Fields with no tag from that list are not logged. To log a field under its
+// Go field name, give it an empty tag value such as `json:""` or `golog:""`.
+//
+// Supported modifiers (comma-separated after the name):
+//   - omitempty — suppress the field when its value is empty per
+//     encoding/json semantics (false, 0, nil pointer/interface, empty
+//     array/slice/map/string).
+//   - omitzero — suppress when the value is zero. Calls IsZero() bool if
+//     the type implements it (so time.Time{} is suppressed), else falls
+//     back to reflect.Value.IsZero().
+//   - omitnull — suppress when the value is null. Calls IsNull() bool if
+//     the type implements it (so zero golog.Timestamp is suppressed),
+//     else falls back to omitzero semantics.
+//   - redact (also spelled "redacted") — replace the value with
+//     "***REDACTED***" in the log output. Suppression modifiers win over
+//     redact: `json:",redact,omitempty"` on an empty string emits nothing,
+//     not the redaction marker.
+//
+// Unknown modifier tokens are ignored silently, matching encoding/json's
+// forward-compat posture.
+//
+// Breaking change vs. earlier versions: the bare form `golog:"redact"`
+// no longer triggers redaction — under the new unified parser it would
+// name the field "redact" in the log. Migrate to `golog:",redact"`.
 func (m *Message) StructFields(strct any) *Message {
 	if m == nil || strct == nil {
 		return m
 	}
-	m.structFields(reflect.ValueOf(strct), "")
+	m.structFields(reflect.ValueOf(strct), "golog", "log", "json")
 	return m
 }
 
-// TaggedStructFields calls Any(fieldTag, fieldValue) for every exported struct field
-// that has the passed keyTag with the tag value not being empty or "-".
-// Tag values are only considered until the first comma character,
-// so `tag:"hello_world,omitempty"` will result in the fieldTag "hello_world".
-// Fields with the following tags will be ignored: `keyTag:"-"`, `keyTag:""` `keyTag:",xxx"`
-// where keyTag is the passed keyTag parameter.
-// Fields with the tag `golog:"redact"` will have their value replaced with "***REDACTED***"
-// (unless keyTag is "golog", in which case the tag value is used as the field key).
+// TaggedStructFields logs each exported field of strct that carries the
+// given keyTag. It follows the same tag-value grammar and modifier set as
+// [Message.StructFields]; see that method's documentation for details.
+//
+// Fields without the keyTag are not logged. Fields where the keyTag value is
+// exactly "-" are skipped. A tag value with an empty name segment (e.g.
+// `json:""` or `json:",omitempty"`) falls back to the Go field name, matching
+// encoding/json.Marshal.
+//
+// Passing the empty string as keyTag is a wildcard: every exported field is
+// logged under its Go field name, regardless of whether it carries any
+// struct tag. This restores the pre-tag-driven "log every exported field"
+// behavior for callers that want it — `TaggedStructFields(s, "")`.
 func (m *Message) TaggedStructFields(strct any, keyTag string) *Message {
 	if m == nil || strct == nil {
 		return m
@@ -411,7 +442,7 @@ func (m *Message) TaggedStructFields(strct any, keyTag string) *Message {
 	return m
 }
 
-func (m *Message) structFields(v reflect.Value, keyTag string) {
+func (m *Message) structFields(v reflect.Value, keyTags ...string) {
 	for v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			return
@@ -421,27 +452,63 @@ func (m *Message) structFields(v reflect.Value, keyTag string) {
 	t := v.Type()
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
-		switch {
-		case field.Anonymous:
-			m.structFields(v.Field(i), keyTag)
-		case token.IsExported(field.Name):
-			var (
-				key   = field.Name
-				value = v.Field(i).Interface()
-			)
-			if keyTag != "golog" && strings.TrimSpace(field.Tag.Get("golog")) == "redact" {
-				value = "***REDACTED***"
-			}
-			if keyTag != "" {
-				key = field.Tag.Get(keyTag)
-				key, _, _ = strings.Cut(key, ",")
-				key = strings.TrimSpace(key)
-				if key == "" || key == "-" {
-					continue
-				}
-			}
-			m.Any(key, value)
+
+		if field.Anonymous {
+			m.structFields(v.Field(i), keyTags...)
+			continue
 		}
+		if !token.IsExported(field.Name) {
+			continue
+		}
+
+		// Find the first keyTag that "matches" this field. Lookup (not
+		// Get) so that an explicit empty tag value like `json:""` counts
+		// as present.
+		//
+		// An empty string in keyTags is a wildcard: it matches every
+		// exported field with an empty raw tag value (which the caller
+		// later substitutes with the Go field name). This gives callers
+		// a way to dump a struct wholesale under Go field names, e.g.
+		// `TaggedStructFields(s, "")` for log-everything, or
+		// `structFields(v, "json", "")` for "prefer json tag, fall back
+		// to Go field name".
+		var rawTag string
+		var found bool
+		for _, kt := range keyTags {
+			if kt == "" {
+				found = true
+				rawTag = ""
+				break
+			}
+			if tv, ok := field.Tag.Lookup(kt); ok {
+				rawTag = tv
+				found = true
+				break
+			}
+		}
+		if !found {
+			continue
+		}
+
+		d := parseStructFieldDirectives(rawTag)
+		if d.skip {
+			continue
+		}
+		if d.key == "" {
+			d.key = field.Name
+		}
+
+		fv := v.Field(i)
+		if shouldOmitStructField(fv, d) {
+			continue
+		}
+
+		if d.redact {
+			m.Str(d.key, "***REDACTED***")
+			continue
+		}
+
+		m.Any(d.key, fv.Interface())
 	}
 }
 

--- a/message_test.go
+++ b/message_test.go
@@ -48,6 +48,39 @@ func newTestLoggerWithPrefix(prefix string) (log *Logger, textOut, jsonOut *byte
 	return NewLoggerWithPrefix(newTestConfig(textOut, jsonOut), prefix), textOut, jsonOut
 }
 
+// tf is a per-field spec for [buildTestStruct].
+type tf struct {
+	name  string
+	tag   string
+	value any
+}
+
+// buildTestStruct assembles an instance of a runtime-generated struct from
+// the given field specs. Tests use it to put golog-specific json tag
+// modifiers (redact, omitnull, etc.) on a struct without triggering static
+// analyzers that inspect AST-level struct tag literals (go vet's structtag
+// and staticcheck's SA5008). Tags live in runtime [reflect.StructField]
+// values, so no analyzer has anything to parse statically.
+//
+// Each field's type is taken from its value's dynamic type, so pass a zero
+// value of the intended field type (e.g. `Timestamp{}` or `(*string)(nil)`)
+// when the field should start zero.
+func buildTestStruct(fields ...tf) any {
+	specs := make([]reflect.StructField, len(fields))
+	for i, f := range fields {
+		specs[i] = reflect.StructField{
+			Name: f.name,
+			Type: reflect.TypeOf(f.value),
+			Tag:  reflect.StructTag(f.tag),
+		}
+	}
+	v := reflect.New(reflect.StructOf(specs)).Elem()
+	for i, f := range fields {
+		v.Field(i).Set(reflect.ValueOf(f.value))
+	}
+	return v.Interface()
+}
+
 func checkOutput(t *testing.T, textOut, jsonOut *bytes.Buffer, numMessages int, exptectedTextLine, exptectedJSONLine string) {
 	t.Helper()
 
@@ -779,10 +812,13 @@ func TestMessage_StructFields(t *testing.T) {
 		textOut.Reset()
 		jsonOut.Reset()
 
+		// Fields use an empty json tag to fall back to the Go field name
+		// under the new tag-driven rules for StructFields.
 		type BasicStruct struct {
-			Name    string
-			Age     int
-			Active  bool
+			Name    string `json:""`
+			Age     int    `json:""`
+			Active  bool   `json:""`
+			Skipped string // no tag → not logged under the new rules
 			private string //nolint:unused
 		}
 
@@ -790,6 +826,7 @@ func TestMessage_StructFields(t *testing.T) {
 			Name:    "John",
 			Age:     30,
 			Active:  true,
+			Skipped: "should_not_appear",
 			private: "hidden",
 		}
 
@@ -800,6 +837,8 @@ func TestMessage_StructFields(t *testing.T) {
 		assert.Contains(t, textOut.String(), `Name="John"`)
 		assert.Contains(t, textOut.String(), `Age=30`)
 		assert.Contains(t, textOut.String(), `Active=true`)
+		assert.NotContains(t, textOut.String(), `Skipped`)
+		assert.NotContains(t, textOut.String(), `should_not_appear`)
 		assert.NotContains(t, textOut.String(), `private`)
 		assert.NotContains(t, textOut.String(), `hidden`)
 	})
@@ -808,11 +847,13 @@ func TestMessage_StructFields(t *testing.T) {
 		textOut.Reset()
 		jsonOut.Reset()
 
+		// Canonical form for redact is now `golog:",redact"`: empty name
+		// falls back to the Go field name, `redact` is a modifier.
 		type UserWithSecrets struct {
-			Username string
-			Password string `golog:"redact"`
-			APIKey   string `golog:"redact"`
-			Email    string
+			Username string `golog:""`
+			Password string `golog:",redact"`
+			APIKey   string `golog:",redact"`
+			Email    string `golog:""`
 		}
 
 		u := UserWithSecrets{
@@ -843,12 +884,12 @@ func TestMessage_StructFields(t *testing.T) {
 		jsonOut.Reset()
 
 		type Embedded struct {
-			EmbeddedField string
+			EmbeddedField string `json:""`
 		}
 
 		type OuterStruct struct {
 			Embedded
-			OuterField string
+			OuterField string `json:""`
 		}
 
 		s := OuterStruct{
@@ -869,7 +910,7 @@ func TestMessage_StructFields(t *testing.T) {
 		jsonOut.Reset()
 
 		type SimpleStruct struct {
-			Value string
+			Value string `json:""`
 		}
 
 		s := &SimpleStruct{Value: "pointer_value"}
@@ -898,6 +939,280 @@ func TestMessage_StructFields(t *testing.T) {
 		// Should not contain any field from the struct
 		assert.NotContains(t, textOut.String(), `Value=`)
 	})
+
+	t.Run("untagged struct logs nothing", func(t *testing.T) {
+		textOut.Reset()
+		jsonOut.Reset()
+
+		// Fields with none of the default keyTags (golog, log, json) are
+		// skipped entirely. This is intentional — differs from encoding/json.
+		type NoTagsStruct struct {
+			A string
+			B int
+			C bool
+		}
+
+		s := NoTagsStruct{A: "x", B: 1, C: true}
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			StructFields(s).
+			Log()
+
+		assert.NotContains(t, textOut.String(), `A=`)
+		assert.NotContains(t, textOut.String(), `B=`)
+		assert.NotContains(t, textOut.String(), `C=`)
+	})
+
+	t.Run("multi-keyTag fallback order", func(t *testing.T) {
+		textOut.Reset()
+		jsonOut.Reset()
+
+		// StructFields prefers golog, then log, then json for naming.
+		type MixedTags struct {
+			A string `golog:"aa"`
+			B string `log:"bb"`
+			C string `json:"cc"`
+			D string `log:"dd_log" json:"dd_json"` // log wins over json
+			E string `golog:"ee_golog" json:"ee_json"` // golog wins over json
+		}
+
+		s := MixedTags{A: "a_val", B: "b_val", C: "c_val", D: "d_val", E: "e_val"}
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			StructFields(s).
+			Log()
+
+		assert.Contains(t, textOut.String(), `aa="a_val"`)
+		assert.Contains(t, textOut.String(), `bb="b_val"`)
+		assert.Contains(t, textOut.String(), `cc="c_val"`)
+		assert.Contains(t, textOut.String(), `dd_log="d_val"`)
+		assert.NotContains(t, textOut.String(), `dd_json`)
+		assert.Contains(t, textOut.String(), `ee_golog="e_val"`)
+		assert.NotContains(t, textOut.String(), `ee_json`)
+	})
+
+	t.Run("winning tag controls modifiers", func(t *testing.T) {
+		textOut.Reset()
+		jsonOut.Reset()
+
+		// golog wins for naming, so json's omitempty is silently discarded.
+		// The field is emitted even though its value is empty.
+		type Mixed struct {
+			A string `golog:"a" json:"b,omitempty"`
+		}
+
+		s := Mixed{A: ""}
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			StructFields(s).
+			Log()
+
+		assert.Contains(t, textOut.String(), `a=""`)
+		assert.NotContains(t, textOut.String(), `b=`)
+	})
+
+	t.Run("golog dash skips the field", func(t *testing.T) {
+		textOut.Reset()
+		jsonOut.Reset()
+
+		type DashedStruct struct {
+			Kept    string `golog:""`
+			Skipped string `golog:"-"`
+		}
+
+		s := DashedStruct{Kept: "k", Skipped: "s"}
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			StructFields(s).
+			Log()
+
+		assert.Contains(t, textOut.String(), `Kept="k"`)
+		assert.NotContains(t, textOut.String(), `Skipped`)
+	})
+
+	t.Run("omitempty in golog tag", func(t *testing.T) {
+		textOut.Reset()
+		jsonOut.Reset()
+
+		type E struct {
+			Str   string            `golog:",omitempty"`
+			Int   int               `golog:",omitempty"`
+			Bool  bool              `golog:",omitempty"`
+			Slice []int             `golog:",omitempty"`
+			Map   map[string]string `golog:",omitempty"`
+			Ptr   *string           `golog:",omitempty"`
+		}
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			StructFields(E{}).
+			Log()
+
+		// All zero values → all skipped.
+		assert.NotContains(t, textOut.String(), `Str=`)
+		assert.NotContains(t, textOut.String(), `Int=`)
+		assert.NotContains(t, textOut.String(), `Bool=`)
+		assert.NotContains(t, textOut.String(), `Slice=`)
+		assert.NotContains(t, textOut.String(), `Map=`)
+		assert.NotContains(t, textOut.String(), `Ptr=`)
+
+		textOut.Reset()
+		jsonOut.Reset()
+
+		strPtr := "p"
+		log.NewMessage(ctx, infoLevel, "Msg").
+			StructFields(E{
+				Str:   "s",
+				Int:   1,
+				Bool:  true,
+				Slice: []int{1},
+				Map:   map[string]string{"k": "v"},
+				Ptr:   &strPtr,
+			}).
+			Log()
+
+		// All non-zero → all present.
+		assert.Contains(t, textOut.String(), `Str="s"`)
+		assert.Contains(t, textOut.String(), `Int=1`)
+		assert.Contains(t, textOut.String(), `Bool=true`)
+		assert.Contains(t, textOut.String(), `Slice=`)
+		assert.Contains(t, textOut.String(), `Map=`)
+		assert.Contains(t, textOut.String(), `Ptr=`)
+	})
+
+	t.Run("omitzero suppresses time.Time via IsZero method", func(t *testing.T) {
+		textOut.Reset()
+		jsonOut.Reset()
+
+		type Z struct {
+			When time.Time `golog:",omitzero"`
+		}
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			StructFields(Z{}).
+			Log()
+
+		// zero time.Time has IsZero()==true → suppressed
+		assert.NotContains(t, textOut.String(), `When=`)
+
+		textOut.Reset()
+		jsonOut.Reset()
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			StructFields(Z{When: time.Date(2026, 4, 14, 0, 0, 0, 0, time.UTC)}).
+			Log()
+
+		assert.Contains(t, textOut.String(), `When=`)
+	})
+
+	t.Run("omitnull suppresses zero golog.Timestamp via IsNull method", func(t *testing.T) {
+		textOut.Reset()
+		jsonOut.Reset()
+
+		type N struct {
+			When Timestamp `golog:",omitnull"`
+		}
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			StructFields(N{}).
+			Log()
+
+		// zero Timestamp has IsNull()==true → suppressed
+		assert.NotContains(t, textOut.String(), `When=`)
+
+		textOut.Reset()
+		jsonOut.Reset()
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			StructFields(N{When: Timestamp{Time: time.Date(2026, 4, 14, 0, 0, 0, 0, time.UTC)}}).
+			Log()
+
+		assert.Contains(t, textOut.String(), `When=`)
+	})
+
+	t.Run("omitnull falls back to omitzero when no IsNull method", func(t *testing.T) {
+		textOut.Reset()
+		jsonOut.Reset()
+
+		// time.Time has IsZero() but no IsNull() — omitnull falls back to
+		// the omitzero path and suppresses the zero value.
+		type F struct {
+			When time.Time `golog:",omitnull"`
+		}
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			StructFields(F{}).
+			Log()
+
+		assert.NotContains(t, textOut.String(), `When=`)
+	})
+
+	t.Run("nil pointer fields do not panic with omit modifiers", func(t *testing.T) {
+		textOut.Reset()
+		jsonOut.Reset()
+
+		// Regression: without the nil-pointer short-circuit in
+		// shouldOmitStructField and isZeroValueForOmitzero, a nil
+		// *Timestamp with ,omitnull or a nil *time.Time with ,omitzero
+		// panics because the value-receiver IsNull / IsZero method
+		// auto-dereferences the nil pointer. Both must now be suppressed
+		// silently.
+		type Event struct {
+			ProcessedAt *time.Time `golog:",omitzero"`
+			DeletedAt   *Timestamp `golog:",omitnull"`
+			UpdatedAt   *time.Time `golog:",omitnull"` // omitnull → omitzero fallback on nil
+		}
+
+		assert.NotPanics(t, func() {
+			log.NewMessage(ctx, infoLevel, "Msg").
+				StructFields(Event{}).
+				Log()
+		}, "nil pointer fields with omit modifiers must not panic")
+
+		assert.NotContains(t, textOut.String(), `ProcessedAt=`)
+		assert.NotContains(t, textOut.String(), `DeletedAt=`)
+		assert.NotContains(t, textOut.String(), `UpdatedAt=`)
+
+		// Non-nil pointer to a non-zero value must still log.
+		textOut.Reset()
+		jsonOut.Reset()
+		t1 := time.Date(2026, 4, 14, 0, 0, 0, 0, time.UTC)
+		ts := Timestamp{Time: t1}
+		log.NewMessage(ctx, infoLevel, "Msg").
+			StructFields(Event{ProcessedAt: &t1, DeletedAt: &ts, UpdatedAt: &t1}).
+			Log()
+		assert.Contains(t, textOut.String(), `ProcessedAt=`)
+		assert.Contains(t, textOut.String(), `DeletedAt=`)
+		assert.Contains(t, textOut.String(), `UpdatedAt=`)
+	})
+
+	t.Run("omitempty wins over redact for empty values", func(t *testing.T) {
+		textOut.Reset()
+		jsonOut.Reset()
+
+		// Empty field with both redact and omitempty is suppressed, not
+		// emitted with ***REDACTED***. Suppression wins — matches
+		// encoding/json omitempty precedence.
+		type R struct {
+			Token string `golog:",redact,omitempty"`
+		}
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			StructFields(R{Token: ""}).
+			Log()
+
+		assert.NotContains(t, textOut.String(), `Token=`)
+		assert.NotContains(t, textOut.String(), `REDACTED`)
+
+		textOut.Reset()
+		jsonOut.Reset()
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			StructFields(R{Token: "secret"}).
+			Log()
+
+		assert.Contains(t, textOut.String(), `Token="***REDACTED***"`)
+		assert.NotContains(t, textOut.String(), `secret`)
+	})
 }
 
 func TestMessage_TaggedStructFields(t *testing.T) {
@@ -914,9 +1229,11 @@ func TestMessage_TaggedStructFields(t *testing.T) {
 		type JSONTaggedStruct struct {
 			UserName string `json:"user_name"`
 			UserAge  int    `json:"user_age"`
-			NoTag    string
+			NoTag    string // no json tag at all → skipped under the new rules
 			Ignored  string `json:"-"`
-			Empty    string `json:""`
+			// Empty json tag value → encoding/json.Marshal parity:
+			// fall back to the Go field name ("Empty") as the log key.
+			Empty string `json:""`
 		}
 
 		s := JSONTaggedStruct{
@@ -933,13 +1250,12 @@ func TestMessage_TaggedStructFields(t *testing.T) {
 
 		assert.Contains(t, textOut.String(), `user_name="John"`)
 		assert.Contains(t, textOut.String(), `user_age=30`)
+		assert.Contains(t, textOut.String(), `Empty="empty_value"`) // json.Marshal parity: empty tag → Go field name
 		assert.NotContains(t, textOut.String(), `UserName`)
 		assert.NotContains(t, textOut.String(), `NoTag`)
 		assert.NotContains(t, textOut.String(), `no_tag_value`)
 		assert.NotContains(t, textOut.String(), `Ignored`)
 		assert.NotContains(t, textOut.String(), `ignored_value`)
-		assert.NotContains(t, textOut.String(), `Empty`)
-		assert.NotContains(t, textOut.String(), `empty_value`)
 	})
 
 	t.Run("json tag with options", func(t *testing.T) {
@@ -969,17 +1285,17 @@ func TestMessage_TaggedStructFields(t *testing.T) {
 		textOut.Reset()
 		jsonOut.Reset()
 
-		type SecureStruct struct {
-			Username string `json:"username"`
-			Password string `json:"password" golog:"redact"`
-			Token    string `json:"token" golog:"redact"`
-		}
-
-		s := SecureStruct{
-			Username: "admin",
-			Password: "super_secret",
-			Token:    "tok_xyz789",
-		}
+		// Under the unified rules modifiers come from the winning tag,
+		// so when TaggedStructFields is called with "json" the redact
+		// modifier must live inside the json tag. "redacted" is accepted
+		// as a synonym for "redact". The struct type is built at runtime
+		// via buildTestStruct so that golog-specific modifiers never live
+		// in static struct tag literals (see buildTestStruct doc).
+		s := buildTestStruct(
+			tf{"Username", `json:"username"`, "admin"},
+			tf{"Password", `json:"password,redact"`, "super_secret"},
+			tf{"Token", `json:"token,redacted"`, "tok_xyz789"},
+		)
 
 		log.NewMessage(ctx, infoLevel, "Msg").
 			TaggedStructFields(s, "json").
@@ -1087,49 +1403,233 @@ func TestMessage_TaggedStructFields(t *testing.T) {
 		assert.NotContains(t, textOut.String(), `=`)
 	})
 
-	t.Run("whitespace in tag value", func(t *testing.T) {
+	// Whitespace trimming in tag values is exercised exhaustively at the
+	// parser level in TestParseStructFieldDirectives. Struct tags with
+	// leading or trailing spaces would trigger `go vet`'s structtag check,
+	// so we do not test whitespace-in-tag-value via real struct tags here.
+
+	t.Run("json omitempty parity", func(t *testing.T) {
 		textOut.Reset()
 		jsonOut.Reset()
 
-		type WhitespaceTagStruct struct {
-			Field1 string `json:"  field_one  "`
-			Field2 string `json:"   "`
-		}
-
-		s := WhitespaceTagStruct{
-			Field1: "value1",
-			Field2: "value2",
+		type OE struct {
+			Present string `json:"present,omitempty"`
+			Missing string `json:"missing,omitempty"`
 		}
 
 		log.NewMessage(ctx, infoLevel, "Msg").
-			TaggedStructFields(s, "json").
+			TaggedStructFields(OE{Present: "hi", Missing: ""}, "json").
 			Log()
 
-		// Trimmed tag value should be used, empty tag after trim should be ignored
-		assert.Contains(t, textOut.String(), `field_one="value1"`)
-		assert.NotContains(t, textOut.String(), `Field2`)
-		assert.NotContains(t, textOut.String(), `value2`)
+		assert.Contains(t, textOut.String(), `present="hi"`)
+		assert.NotContains(t, textOut.String(), `missing`)
 	})
 
-	t.Run("redact with whitespace", func(t *testing.T) {
+	t.Run("json omitempty with empty name falls back to field name", func(t *testing.T) {
 		textOut.Reset()
 		jsonOut.Reset()
 
-		type WhitespaceRedactStruct struct {
-			Password string `json:"password" golog:" redact "`
-		}
-
-		s := WhitespaceRedactStruct{
-			Password: "secret",
+		type OEF struct {
+			Present string `json:",omitempty"`
+			Missing string `json:",omitempty"`
 		}
 
 		log.NewMessage(ctx, infoLevel, "Msg").
-			TaggedStructFields(s, "json").
+			TaggedStructFields(OEF{Present: "hi", Missing: ""}, "json").
 			Log()
 
-		// Should still redact even with whitespace around "redact"
-		assert.Contains(t, textOut.String(), `password="***REDACTED***"`)
+		// Present falls back to field name "Present" and is emitted.
+		// Missing falls back to "Missing" but omitempty suppresses it.
+		assert.Contains(t, textOut.String(), `Present="hi"`)
+		assert.NotContains(t, textOut.String(), `Missing`)
+	})
+
+	t.Run("json omitzero with time.Time", func(t *testing.T) {
+		textOut.Reset()
+		jsonOut.Reset()
+
+		type OZ struct {
+			When time.Time `json:"when,omitzero"`
+		}
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			TaggedStructFields(OZ{}, "json").
+			Log()
+		assert.NotContains(t, textOut.String(), `when=`)
+
+		textOut.Reset()
+		jsonOut.Reset()
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			TaggedStructFields(OZ{When: time.Date(2026, 4, 14, 0, 0, 0, 0, time.UTC)}, "json").
+			Log()
+		assert.Contains(t, textOut.String(), `when=`)
+	})
+
+	t.Run("json omitnull with Timestamp", func(t *testing.T) {
+		textOut.Reset()
+		jsonOut.Reset()
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			TaggedStructFields(
+				buildTestStruct(tf{"At", `json:"at,omitnull"`, Timestamp{}}),
+				"json",
+			).
+			Log()
+		assert.NotContains(t, textOut.String(), `at=`)
+
+		textOut.Reset()
+		jsonOut.Reset()
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			TaggedStructFields(
+				buildTestStruct(tf{
+					"At", `json:"at,omitnull"`,
+					Timestamp{Time: time.Date(2026, 4, 14, 0, 0, 0, 0, time.UTC)},
+				}),
+				"json",
+			).
+			Log()
+		assert.Contains(t, textOut.String(), `at=`)
+	})
+
+	t.Run("json omitnull falls back to omitzero when no IsNull method", func(t *testing.T) {
+		textOut.Reset()
+		jsonOut.Reset()
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			TaggedStructFields(
+				buildTestStruct(tf{"When", `json:"when,omitnull"`, time.Time{}}),
+				"json",
+			).
+			Log()
+		assert.NotContains(t, textOut.String(), `when=`)
+	})
+
+	t.Run("redact omitempty precedence in json tag", func(t *testing.T) {
+		textOut.Reset()
+		jsonOut.Reset()
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			TaggedStructFields(
+				buildTestStruct(tf{"Token", `json:"token,redact,omitempty"`, ""}),
+				"json",
+			).
+			Log()
+		assert.NotContains(t, textOut.String(), `token=`)
+		assert.NotContains(t, textOut.String(), `REDACTED`)
+
+		textOut.Reset()
+		jsonOut.Reset()
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			TaggedStructFields(
+				buildTestStruct(tf{"Token", `json:"token,redact,omitempty"`, "secret"}),
+				"json",
+			).
+			Log()
+		assert.Contains(t, textOut.String(), `token="***REDACTED***"`)
 		assert.NotContains(t, textOut.String(), `secret`)
+	})
+
+	t.Run("json dash with trailing modifier is literal name", func(t *testing.T) {
+		textOut.Reset()
+		jsonOut.Reset()
+
+		// `json:"-,omitempty"` means the literal field name "-" with the
+		// omitempty modifier — matches encoding/json.Marshal. Only a bare
+		// `json:"-"` with no comma skips.
+		type DashNames struct {
+			Literal string `json:"-,omitempty"`
+			Normal  string `json:"normal"`
+		}
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			TaggedStructFields(DashNames{Literal: "kept", Normal: "n"}, "json").
+			Log()
+
+		assert.Contains(t, textOut.String(), `-="kept"`)
+		assert.Contains(t, textOut.String(), `normal="n"`)
+
+		textOut.Reset()
+		jsonOut.Reset()
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			TaggedStructFields(DashNames{Literal: "", Normal: "n"}, "json").
+			Log()
+
+		// Empty literal "-" field → omitempty suppresses it.
+		assert.NotContains(t, textOut.String(), `-=`)
+		assert.Contains(t, textOut.String(), `normal="n"`)
+	})
+
+	t.Run("empty keyTag is wildcard that logs every exported field by Go name", func(t *testing.T) {
+		textOut.Reset()
+		jsonOut.Reset()
+
+		// `TaggedStructFields(s, "")` is the escape hatch for "log every
+		// exported field by its Go name", regardless of whether the field
+		// carries a struct tag. This restores the pre-tag-driven
+		// StructFields behavior for callers that want it.
+		type Wild struct {
+			A string
+			B int
+			C bool
+			d string //nolint:unused
+		}
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			TaggedStructFields(Wild{A: "x", B: 1, C: true, d: "hidden"}, "").
+			Log()
+
+		assert.Contains(t, textOut.String(), `A="x"`)
+		assert.Contains(t, textOut.String(), `B=1`)
+		assert.Contains(t, textOut.String(), `C=true`)
+		assert.NotContains(t, textOut.String(), `d=`)
+		assert.NotContains(t, textOut.String(), `hidden`)
+	})
+
+	t.Run("empty keyTag ignores struct tags on the fields", func(t *testing.T) {
+		textOut.Reset()
+		jsonOut.Reset()
+
+		// Empty keyTag is a wildcard: it short-circuits the tag lookup
+		// and uses the Go field name even when the field HAS a tag like
+		// `json:"aaa"`. This is the semantic "log every field, no
+		// renames".
+		type Named struct {
+			Foo string `json:"aaa"`
+			Bar int    `json:"bbb,omitempty"`
+		}
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			TaggedStructFields(Named{Foo: "v", Bar: 0}, "").
+			Log()
+
+		assert.Contains(t, textOut.String(), `Foo="v"`)
+		// Bar is zero, but the empty-keyTag wildcard has no modifiers,
+		// so omitempty from the json tag does NOT apply.
+		assert.Contains(t, textOut.String(), `Bar=0`)
+		assert.NotContains(t, textOut.String(), `aaa`)
+		assert.NotContains(t, textOut.String(), `bbb`)
+	})
+
+	t.Run("unknown modifier is ignored silently", func(t *testing.T) {
+		textOut.Reset()
+		jsonOut.Reset()
+
+		// Tag string is built at runtime so no analyzer can pattern-match
+		// a compile-time `json:"..."` literal containing "wibble".
+		unknownTag := fmt.Sprintf(`json:%q`, "x,wibble,omitempty")
+
+		log.NewMessage(ctx, infoLevel, "Msg").
+			TaggedStructFields(
+				buildTestStruct(tf{"X", unknownTag, "val"}),
+				"json",
+			).
+			Log()
+
+		assert.Contains(t, textOut.String(), `x="val"`)
 	})
 }
 

--- a/struct.go
+++ b/struct.go
@@ -1,0 +1,199 @@
+package golog
+
+import (
+	"reflect"
+	"strings"
+)
+
+// Interface types for the IsNull and IsZero method checks used by the
+// omitnull and omitzero modifiers. Declared once at package level so we
+// can cheaply test whether reflect.PointerTo(T) implements them.
+var (
+	isNullIfaceType = reflect.TypeOf((*interface{ IsNull() bool })(nil)).Elem()
+	isZeroIfaceType = reflect.TypeOf((*interface{ IsZero() bool })(nil)).Elem()
+)
+
+// structFieldDirectives is the parsed result of a struct tag value such as
+// "name,omitempty,redact" — see parseStructFieldDirectives.
+type structFieldDirectives struct {
+	key       string // explicit tag name; empty means "use field.Name"
+	skip      bool   // tag value was exactly "-"
+	redact    bool
+	omitempty bool
+	omitzero  bool
+	omitnull  bool
+}
+
+// parseStructFieldDirectives parses a raw struct tag value (the string after
+// the tag name, e.g. the "name,omitempty,redact" part of `json:"name,omitempty,redact"`)
+// into a structFieldDirectives. The caller is responsible for looking the tag
+// up on the struct field; this helper only parses the value.
+//
+// Rules:
+//   - Bare "-" (no comma) → skip the field.
+//   - Empty name ("" or ",...") → key left empty; caller substitutes field.Name.
+//   - Recognized modifiers: omitempty, omitzero, omitnull, redact (also spelled
+//     "redacted" for the redact modifier).
+//   - Unknown modifier tokens are ignored silently (matches encoding/json).
+//   - Whitespace around the name and each modifier is trimmed.
+func parseStructFieldDirectives(value string) structFieldDirectives {
+	var d structFieldDirectives
+
+	name, rest, hasRest := strings.Cut(value, ",")
+	name = strings.TrimSpace(name)
+
+	if name == "-" && !hasRest {
+		d.skip = true
+		return d
+	}
+	d.key = name
+
+	for rest != "" {
+		var mod string
+		mod, rest, _ = strings.Cut(rest, ",")
+		switch strings.TrimSpace(mod) {
+		case "redact", "redacted":
+			d.redact = true
+		case "omitempty":
+			d.omitempty = true
+		case "omitzero":
+			d.omitzero = true
+		case "omitnull":
+			d.omitnull = true
+		}
+	}
+	return d
+}
+
+// shouldOmitStructField reports whether fv should be suppressed from log
+// output per the given directives. The three suppression modifiers are OR'd:
+// any passing check suppresses the field.
+func shouldOmitStructField(fv reflect.Value, d structFieldDirectives) bool {
+	if d.omitnull {
+		// A nil pointer or interface is definitively null. Short-circuit
+		// before the interface assertion: a nil *T with a value-receiver
+		// IsNull method would otherwise panic when IsNull auto-dereferences
+		// the nil pointer.
+		if (fv.Kind() == reflect.Pointer || fv.Kind() == reflect.Interface) && fv.IsNil() {
+			return true
+		}
+		if isNull, ok := invokeIsNull(fv); ok {
+			if isNull {
+				return true
+			}
+		} else if isZeroValueForOmitzero(fv) {
+			return true
+		}
+	}
+	if d.omitzero && isZeroValueForOmitzero(fv) {
+		return true
+	}
+	if d.omitempty && isEmptyValueForOmitempty(fv) {
+		return true
+	}
+	return false
+}
+
+// invokeIsNull calls IsNull() bool on fv if its dynamic type implements the
+// interface, handling both value-receiver and pointer-receiver methods.
+// Returns (result, true) if the method was called, or (false, false) if the
+// type does not implement IsNull at all.
+//
+// The pointer-receiver path needs an addressable form of fv. If fv is
+// already addressable (because its enclosing struct was reached via a
+// pointer), we take its address directly. Otherwise we allocate a fresh
+// copy so we can call the method without panicking.
+func invokeIsNull(fv reflect.Value) (result, ok bool) {
+	// Value-receiver fast path: no allocation, works when fv's type itself
+	// is in the method set.
+	if n, ok := fv.Interface().(interface{ IsNull() bool }); ok {
+		return n.IsNull(), true
+	}
+	// Pointer-receiver path: only applies if *T has the method.
+	if !reflect.PointerTo(fv.Type()).Implements(isNullIfaceType) {
+		return false, false
+	}
+	addr := asAddressableValue(fv).Addr()
+	return addr.Interface().(interface{ IsNull() bool }).IsNull(), true
+}
+
+// invokeIsZero calls IsZero() bool on fv if its dynamic type implements the
+// interface, handling both value-receiver and pointer-receiver methods.
+// See invokeIsNull for the addressability strategy.
+func invokeIsZero(fv reflect.Value) (result, ok bool) {
+	if z, ok := fv.Interface().(interface{ IsZero() bool }); ok {
+		return z.IsZero(), true
+	}
+	if !reflect.PointerTo(fv.Type()).Implements(isZeroIfaceType) {
+		return false, false
+	}
+	addr := asAddressableValue(fv).Addr()
+	return addr.Interface().(interface{ IsZero() bool }).IsZero(), true
+}
+
+// asAddressableValue returns fv if it is already addressable, otherwise a
+// fresh addressable copy of fv. The returned value has the same type as
+// fv; call .Addr() on it to obtain a pointer.
+//
+// Struct fields obtained by walking a value (reflect.ValueOf(structValue))
+// are not addressable; fields reached via a pointer
+// (reflect.ValueOf(&structValue).Elem()) are. The copy path costs one
+// allocation and is only used when fv is not already addressable AND its
+// pointer type implements the method we want to call.
+func asAddressableValue(fv reflect.Value) reflect.Value {
+	if fv.CanAddr() {
+		return fv
+	}
+	tmp := reflect.New(fv.Type()).Elem()
+	tmp.Set(fv)
+	return tmp
+}
+
+// isZeroValueForOmitzero reports whether fv should be treated as zero for
+// the omitzero modifier. It implements a superset of encoding/json's Go 1.24
+// omitzero rule: if the value's type has an IsZero() bool method, that method
+// is called first — and if it returns false, we ALSO check the Go zero value
+// via reflect.Value.IsZero. Either one returning true is enough to suppress.
+//
+// The union matters for types whose IsZero method does not inspect every
+// field (or inspects logical nullness rather than bit-for-bit zero): we still
+// suppress a bit-for-bit uninitialized default. For types without an IsZero
+// method, this reduces to plain reflect.Value.IsZero, which is the Go spec's
+// "zero value" definition used by encoding/json's omitzero fallback.
+//
+// Both value-receiver and pointer-receiver IsZero methods are honored;
+// see invokeIsZero for the addressability strategy.
+func isZeroValueForOmitzero(fv reflect.Value) bool {
+	// Nil pointer or interface is zero by definition. Short-circuit before
+	// the interface assertion so a nil *T with a value-receiver IsZero
+	// method does not panic on nil-pointer dereference.
+	if (fv.Kind() == reflect.Pointer || fv.Kind() == reflect.Interface) && fv.IsNil() {
+		return true
+	}
+	if isZero, ok := invokeIsZero(fv); ok && isZero {
+		return true
+	}
+	return fv.IsZero()
+}
+
+// isEmptyValueForOmitempty mirrors encoding/json's omitempty definition:
+// false, 0, a nil pointer or interface, or an empty array/slice/map/string.
+// It does NOT treat zero structs or time.Time{} as empty — that is what
+// omitzero is for.
+func isEmptyValueForOmitempty(fv reflect.Value) bool {
+	switch fv.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return fv.Len() == 0
+	case reflect.Bool:
+		return !fv.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return fv.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return fv.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return fv.Float() == 0
+	case reflect.Interface, reflect.Pointer:
+		return fv.IsNil()
+	}
+	return false
+}

--- a/struct_test.go
+++ b/struct_test.go
@@ -1,0 +1,261 @@
+package golog
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestParseStructFieldDirectives covers parseStructFieldDirectives directly
+// without going through the Message/reflect pipeline. This is cheap enough to
+// exhaustively cover whitespace, modifier spelling, edge cases, and forward
+// compatibility (unknown modifiers).
+func TestParseStructFieldDirectives(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  structFieldDirectives
+	}{
+		{"empty", "", structFieldDirectives{}},
+		{"bare dash skips", "-", structFieldDirectives{skip: true}},
+		{"dash with empty trailer is literal name", "-,", structFieldDirectives{key: "-"}},
+		{"dash with modifier is literal name", "-,omitempty", structFieldDirectives{key: "-", omitempty: true}},
+		{"name only", "name", structFieldDirectives{key: "name"}},
+		{"name with omitempty", "name,omitempty", structFieldDirectives{key: "name", omitempty: true}},
+		{"name with omitzero", "name,omitzero", structFieldDirectives{key: "name", omitzero: true}},
+		{"name with omitnull", "name,omitnull", structFieldDirectives{key: "name", omitnull: true}},
+		{"name with redact", "name,redact", structFieldDirectives{key: "name", redact: true}},
+		{"name with redacted alias", "name,redacted", structFieldDirectives{key: "name", redact: true}},
+		{"empty name with omitempty", ",omitempty", structFieldDirectives{omitempty: true}},
+		{"all four modifiers", "name,redact,omitempty,omitzero,omitnull", structFieldDirectives{
+			key: "name", redact: true, omitempty: true, omitzero: true, omitnull: true,
+		}},
+		{"unknown modifier ignored", "name,WIBBLE,omitempty", structFieldDirectives{key: "name", omitempty: true}},
+		{"multiple unknown modifiers ignored", "name,foo,bar,baz", structFieldDirectives{key: "name"}},
+		{"whitespace around name", "  name  ", structFieldDirectives{key: "name"}},
+		{"whitespace around modifiers", "name ,  omitempty  ,  redact  ", structFieldDirectives{
+			key: "name", omitempty: true, redact: true,
+		}},
+		{"whitespace-only name falls back to empty", "   ", structFieldDirectives{}},
+		{"whitespace-only name with modifier", "   ,omitempty", structFieldDirectives{omitempty: true}},
+		{"double comma tolerated", "name,,omitempty", structFieldDirectives{key: "name", omitempty: true}},
+		{"trailing comma tolerated", "name,omitempty,", structFieldDirectives{key: "name", omitempty: true}},
+		{"leading dash not followed by comma is skip", "-", structFieldDirectives{skip: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseStructFieldDirectives(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// ptrRcvNull has IsNull defined on the pointer receiver, so a plain
+// ptrRcvNull value (not *ptrRcvNull) does NOT satisfy
+// interface{ IsNull() bool } via direct assertion; detection requires
+// taking the address of the value first.
+type ptrRcvNull struct{ isnull bool }
+
+func (p *ptrRcvNull) IsNull() bool { return p.isnull }
+
+// ptrRcvZero has IsZero defined on the pointer receiver. Same story.
+type ptrRcvZero struct{ n int }
+
+func (p *ptrRcvZero) IsZero() bool { return p.n == 0 }
+
+// TestShouldOmitStructField_PointerReceiver pins the detection of
+// pointer-receiver IsNull and IsZero methods on non-addressable struct
+// fields. Without the addressable-copy fallback in invokeIsNull and
+// invokeIsZero, these would silently fall through to the generic
+// reflect.Value.IsZero check and return wrong results for types whose
+// IsNull / IsZero semantics differ from bit-for-bit zero.
+func TestShouldOmitStructField_PointerReceiver(t *testing.T) {
+	t.Run("IsNull pointer-receiver on non-addressable field, true", func(t *testing.T) {
+		type S struct{ N ptrRcvNull }
+		s := S{N: ptrRcvNull{isnull: true}}
+		fv := reflect.ValueOf(s).Field(0)
+		assert.False(t, fv.CanAddr(), "fv must be non-addressable for this test")
+		got := shouldOmitStructField(fv, structFieldDirectives{omitnull: true})
+		assert.True(t, got, "pointer-receiver IsNull must be detected and return true")
+	})
+
+	t.Run("IsNull pointer-receiver on non-addressable field, false", func(t *testing.T) {
+		type S struct{ N ptrRcvNull }
+		s := S{N: ptrRcvNull{isnull: false}}
+		fv := reflect.ValueOf(s).Field(0)
+		got := shouldOmitStructField(fv, structFieldDirectives{omitnull: true})
+		assert.False(t, got, "IsNull false must NOT suppress")
+	})
+
+	t.Run("IsZero pointer-receiver on non-addressable field, true", func(t *testing.T) {
+		type S struct{ Z ptrRcvZero }
+		s := S{Z: ptrRcvZero{n: 0}}
+		fv := reflect.ValueOf(s).Field(0)
+		assert.False(t, fv.CanAddr(), "fv must be non-addressable for this test")
+		got := isZeroValueForOmitzero(fv)
+		assert.True(t, got, "pointer-receiver IsZero must be detected and return true")
+	})
+
+	t.Run("IsZero pointer-receiver on non-addressable field, false", func(t *testing.T) {
+		type S struct{ Z ptrRcvZero }
+		s := S{Z: ptrRcvZero{n: 42}}
+		fv := reflect.ValueOf(s).Field(0)
+		got := isZeroValueForOmitzero(fv)
+		assert.False(t, got, "IsZero false must NOT report as zero (the method wins)")
+	})
+
+	t.Run("IsNull pointer-receiver on addressable field, true", func(t *testing.T) {
+		// When the enclosing struct is reached via a pointer, fields
+		// are addressable — the faster CanAddr path in invokeIsNull runs.
+		type S struct{ N ptrRcvNull }
+		s := &S{N: ptrRcvNull{isnull: true}}
+		fv := reflect.ValueOf(s).Elem().Field(0)
+		assert.True(t, fv.CanAddr(), "fv must be addressable for this test")
+		got := shouldOmitStructField(fv, structFieldDirectives{omitnull: true})
+		assert.True(t, got, "pointer-receiver IsNull on addressable field must work")
+	})
+
+	t.Run("IsZero pointer-receiver on addressable field, true", func(t *testing.T) {
+		type S struct{ Z ptrRcvZero }
+		s := &S{Z: ptrRcvZero{n: 0}}
+		fv := reflect.ValueOf(s).Elem().Field(0)
+		assert.True(t, fv.CanAddr(), "fv must be addressable for this test")
+		got := isZeroValueForOmitzero(fv)
+		assert.True(t, got, "pointer-receiver IsZero on addressable field must work")
+	})
+
+	t.Run("invokeIsNull returns ok=false when no method at all", func(t *testing.T) {
+		type plain struct{ x int }
+		fv := reflect.ValueOf(plain{x: 7})
+		_, ok := invokeIsNull(fv)
+		assert.False(t, ok, "plain type with no IsNull method must return ok=false")
+	})
+
+	t.Run("invokeIsZero returns ok=false when no method at all", func(t *testing.T) {
+		type plain struct{ x int }
+		fv := reflect.ValueOf(plain{x: 7})
+		_, ok := invokeIsZero(fv)
+		assert.False(t, ok, "plain type with no IsZero method must return ok=false")
+	})
+}
+
+// TestShouldOmitStructField_NilPointer pins the nil-pointer short-circuit
+// in shouldOmitStructField and isZeroValueForOmitzero. Without the short-
+// circuit, a nil *Timestamp with ,omitnull (or a nil *time.Time with
+// ,omitzero) panics because the value-receiver IsNull / IsZero method
+// auto-dereferences the nil pointer.
+func TestShouldOmitStructField_NilPointer(t *testing.T) {
+	t.Run("nil *Timestamp with omitnull", func(t *testing.T) {
+		type S struct{ P *Timestamp }
+		fv := reflect.ValueOf(S{P: nil}).Field(0)
+		// Pre-fix: this call panicked. Must now return true (suppress).
+		got := shouldOmitStructField(fv, structFieldDirectives{omitnull: true})
+		assert.True(t, got, "nil *Timestamp with omitnull must suppress, not panic")
+	})
+
+	t.Run("nil *time.Time with omitzero", func(t *testing.T) {
+		type S struct{ T *time.Time }
+		fv := reflect.ValueOf(S{T: nil}).Field(0)
+		got := shouldOmitStructField(fv, structFieldDirectives{omitzero: true})
+		assert.True(t, got, "nil *time.Time with omitzero must suppress, not panic")
+	})
+
+	t.Run("nil *time.Time with omitnull falls back via nil check", func(t *testing.T) {
+		// *time.Time has no IsNull method, so omitnull falls through to the
+		// omitzero path. The nil-pointer short-circuit in
+		// isZeroValueForOmitzero must catch this before IsZero is called.
+		type S struct{ T *time.Time }
+		fv := reflect.ValueOf(S{T: nil}).Field(0)
+		got := shouldOmitStructField(fv, structFieldDirectives{omitnull: true})
+		assert.True(t, got, "nil *time.Time with omitnull must suppress via omitzero fallback, not panic")
+	})
+
+	t.Run("nil interface with omitnull", func(t *testing.T) {
+		type S struct{ I any }
+		fv := reflect.ValueOf(S{I: nil}).Field(0)
+		got := shouldOmitStructField(fv, structFieldDirectives{omitnull: true})
+		assert.True(t, got, "nil interface with omitnull must suppress, not panic")
+	})
+
+	t.Run("non-nil *Timestamp with omitnull preserves previous behavior", func(t *testing.T) {
+		// Sanity: fix must not regress the non-nil path. A pointer to a
+		// zero Timestamp (IsNull==true) must still suppress.
+		ts := Timestamp{}
+		type S struct{ P *Timestamp }
+		fv := reflect.ValueOf(S{P: &ts}).Field(0)
+		got := shouldOmitStructField(fv, structFieldDirectives{omitnull: true})
+		assert.True(t, got, "pointer to zero Timestamp with omitnull must suppress via IsNull")
+
+		// And a pointer to a non-zero Timestamp must NOT suppress.
+		ts2 := Timestamp{Time: time.Date(2026, 4, 14, 0, 0, 0, 0, time.UTC)}
+		fv2 := reflect.ValueOf(S{P: &ts2}).Field(0)
+		got2 := shouldOmitStructField(fv2, structFieldDirectives{omitnull: true})
+		assert.False(t, got2, "pointer to non-zero Timestamp with omitnull must not suppress")
+	})
+}
+
+// TestEncodingJSONIgnoresCustomModifiers pins a load-bearing assumption of
+// the struct-field modifier design: `encoding/json.Marshal` must ignore
+// golog-specific modifiers (redact, redacted, omitnull) silently, so that a
+// tag like `json:"name,omitnull"` is valid for both packages — golog honors
+// the modifier, encoding/json falls through. If a future Go release changes
+// this, this test fails and the plan needs revisiting.
+//
+// The struct type is constructed at runtime via [reflect.StructOf] so that
+// the json tags with golog-specific modifiers never appear as static struct
+// tag literals in the source — both `go vet` (structtag) and staticcheck
+// (SA5008) inspect AST-level struct tag declarations, and neither has any
+// string literal to complain about when the tag lives in a
+// [reflect.StructField] value at runtime.
+func TestEncodingJSONIgnoresCustomModifiers(t *testing.T) {
+	stringType := reflect.TypeFor[string]()
+	structType := reflect.StructOf([]reflect.StructField{
+		{Name: "A", Type: stringType, Tag: `json:"a,redact"`},
+		{Name: "B", Type: stringType, Tag: `json:"b,redacted"`},
+		{Name: "C", Type: stringType, Tag: `json:"c,omitnull"`},
+		{Name: "D", Type: stringType, Tag: `json:"d,omitempty,omitnull,redact"`},
+		{Name: "E", Type: stringType, Tag: `json:"e,omitempty"`},
+	})
+
+	fill := func(a, b, c, d, e string) any {
+		v := reflect.New(structType).Elem()
+		v.FieldByName("A").SetString(a)
+		v.FieldByName("B").SetString(b)
+		v.FieldByName("C").SetString(c)
+		v.FieldByName("D").SetString(d)
+		v.FieldByName("E").SetString(e)
+		return v.Interface()
+	}
+
+	out, err := json.Marshal(fill("a_val", "b_val", "c_val", "d_val", "e_val"))
+	if err != nil {
+		t.Fatalf("encoding/json marshal failed: %v", err)
+	}
+	got := string(out)
+
+	// All five fields appear with their tag names and original values —
+	// the custom modifiers are no-ops for encoding/json. The only modifier
+	// encoding/json actually honors here is omitempty on E, which has no
+	// effect because E is non-empty.
+	assert.Contains(t, got, `"a":"a_val"`)
+	assert.Contains(t, got, `"b":"b_val"`)
+	assert.Contains(t, got, `"c":"c_val"`)
+	assert.Contains(t, got, `"d":"d_val"`)
+	assert.Contains(t, got, `"e":"e_val"`)
+
+	// Prove encoding/json would NOT emit an empty E (omitempty is real) —
+	// our custom modifiers on D don't interfere with the omitempty that
+	// encoding/json does understand on the same tag.
+	out, err = json.Marshal(fill("a", "b", "c", "", ""))
+	if err != nil {
+		t.Fatalf("encoding/json marshal failed: %v", err)
+	}
+	got = string(out)
+	assert.NotContains(t, got, `"e":`)
+	// D has omitempty too — encoding/json suppresses it when empty.
+	assert.NotContains(t, got, `"d":`)
+}


### PR DESCRIPTION
## Summary

- Unified `Message.StructFields` and `Message.TaggedStructFields` onto a single variadic `structFields(v, keyTags ...string)` core. `StructFields` now resolves tags in the order `golog`, `log`, `json` (first match wins). `TaggedStructFields` is a single-tag shortcut.
- Recognized modifiers on any tag value: `omitempty`, `omitzero`, `omitnull`, and `redact` (also spelled `redacted`). Suppression modifiers win over `redact` (matches `encoding/json.Marshal`'s `omitempty` precedence).
- `omitempty` matches `encoding/json.Marshal` exactly; `omitzero` is a strict superset of `encoding/json`'s Go 1.24 `omitzero` (unions the `IsZero() bool` method result with `reflect.Value.IsZero`); `omitnull` calls `IsNull() bool` and falls back to `omitzero` semantics when the type has no such method. **Both value-receiver and pointer-receiver `IsNull` / `IsZero` methods are honored**, even on non-addressable struct fields (the helper allocates a one-time addressable copy when needed).
- **Wildcard escape hatch:** `TaggedStructFields(s, "")` now logs every exported field by its Go name with no rename and no modifier pickup. This restores the pre-rewrite "log every exported field" behavior as an explicit opt-in. `StructFields(s)` deliberately stays strict tag-driven.
- Unknown modifier tokens are ignored silently so that `json:"name,omitnull"` is a valid tag for both `encoding/json.Marshal` (ignores it) and golog (honors it). A new test, `TestEncodingJSONIgnoresCustomModifiers`, pins that assumption against the stdlib — if a future Go release starts validating these, CI will flag it.

## Tag value grammar

| Raw tag value      | Log key       | Notes                                 |
|--------------------|---------------|---------------------------------------|
| `"field_name"`     | `field_name`  | explicit name                         |
| `""`               | Go field name | empty → fall back to Go name          |
| `",omitempty"`     | Go field name | empty name + modifier                 |
| `"-"` (bare)       | *skipped*     | only the bare form skips              |
| `"-,omitempty"`    | `-`           | literal field name `-` + modifiers    |

Whitespace around the name and each modifier is trimmed. Modifiers from other tags on the same field are ignored — only the first-matching tag contributes both the name and the modifiers.

## Breaking changes

1. **`golog:"redact"` (bare, single token) no longer triggers redaction.** Under the unified parser it names the field `"redact"`. Migrate to `golog:",redact"` (or combine: `golog:",redact,omitempty"`).
2. **`StructFields(s)` on an untagged struct now logs nothing.** Previously every exported field was logged by its Go name. The cleanest replacement is the new `TaggedStructFields(s, "")` wildcard. Per-field, you can also opt in by adding an empty tag like `json:""` or `golog:""`.
3. **`TaggedStructFields(s, "json")` with `json:""` now logs the field** (under its Go name) instead of skipping it. This is `encoding/json.Marshal` parity.

## Test plan

- [x] `go test ./...` passes — full coverage adds ~60 subtests across `TestMessage_StructFields`, `TestMessage_TaggedStructFields`, `TestParseStructFieldDirectives` (21-case table-driven parser test), `TestShouldOmitStructField_NilPointer` (5 subtests, regression guard for the panic fix), `TestShouldOmitStructField_PointerReceiver` (8 subtests, value-receiver + pointer-receiver methods on addressable + non-addressable fields), and `TestEncodingJSONIgnoresCustomModifiers`.
- [x] `go vet ./...` clean.
- [x] `go build ./...` clean.
- [x] `staticcheck -checks SA5008 ./...` clean (custom modifiers in test json tags live in `reflect.StructOf`-built types via the `buildTestStruct` helper, so no AST-level struct tag literals trigger the check).
- [x] Existing `golog:"redact"` tests migrated to `golog:",redact"` + `json:"name,redact"` and still assert the `"***REDACTED***"` substitution.
- [x] `omitnull` verified on `golog.Timestamp` (uses `IsNull`) and `time.Time` (falls back to `omitzero`).
- [x] `omitzero` verified on `time.Time{}` and on zero structs without an `IsZero` method.
- [x] Precedence guard: `,redact,omitempty` on an empty string suppresses the field rather than emitting the redaction marker.
- [x] **Nil-pointer regression guard:** `*time.Time` with `,omitzero` and `*golog.Timestamp` with `,omitnull` (both nil) are suppressed instead of panicking on the value-receiver method auto-dereference. End-to-end test through `Message.StructFields` plus direct predicate tests.
- [x] **Pointer-receiver method coverage:** custom types with `func (p *T) IsNull() bool` and `func (p *T) IsZero() bool` are detected as value fields in non-addressable structs (allocates an addressable copy) and via the fast `Addr()` path on addressable structs.
- [x] **Empty keyTag wildcard:** `TaggedStructFields(s, "")` logs every exported field by Go name, ignores struct tags entirely, skips unexported fields.
- [x] `encoding/json.Marshal` stdlib assumption pinned by a test.

## Documentation

Latest doc-release sweep on this branch:

- **README.md `### Struct Field Logging: Tags and Modifiers`** — full grammar, modifier table, complete example struct, breaking-changes callout, and an `omitnull` vs `omitzero` note using `sql.NullString` as the canonical "null is not zero" example.
- **README.md "Tag resolution" subsection** — adds the wildcard escape-hatch paragraph documenting `TaggedStructFields(s, "")`.
- **README.md "Modifiers" table** — `omitzero` and `omitnull` rows now note that both value-receiver and pointer-receiver methods are honored, matching the `addressable-copy fallback` in `invokeIsNull` / `invokeIsZero`.
- **README.md "Breaking changes" callout** — `StructFields(s)` migration tip now points at `TaggedStructFields(s, "")` as the cleanest restore path.
- **README.md feature bullet list** — mentions tag-driven struct logging with the four modifiers.
- **`Message.StructFields` and `Message.TaggedStructFields` godoc** — expanded with the new grammar, modifier semantics, the wildcard `TaggedStructFields(s, "")` opt-in, and a pointer to the breaking change.
- **Subpackage READMEs** (`benchmarks/`, `goslog/`, `logfile/`, `logsentry/`) — audited, no changes required (none reference the renamed/repurposed methods).
